### PR TITLE
Omitting examples dir from codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ source =
   simulator
 omit =
   *tests*
+  *examples*


### PR DESCRIPTION
In trying to investigate test coverage, we'll exclude the examples directory from the codecov, as this is not part of the main package.

---

## Type of Change

_Mark an `x` in the boxes that apply:_

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation update
- [ x] Tests

