### PR TITLE
Limit CI job concurrency

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,6 +17,10 @@ on:
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
# Pull Request

## Title

Limits CI Job concurrency so that frequent pushes to a PR don't have to queue on itself when running CI jobs.

However, multiple different PR CI jobs can run simultaneously.

---

## Description

See Also:

- <https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs>

---

## Type of Change

- Tests

---