### PR TITLE
Remove file generation of metadata.txt as being redundant

### DIFF
--- a/src/vasim/recommender/cluster_state_provider/FileClusterStateProvider.py
+++ b/src/vasim/recommender/cluster_state_provider/FileClusterStateProvider.py
@@ -57,26 +57,7 @@ class FileClusterStateProvider(ClusterStateProvider):
         # TODO: rename this, it's a bit confusing. It's not the features of the model, it's the features of the data.
         self.features = features or []
         # TODO: a lot of the code below needs testing
-
-        # create an empty config object, and give it a general_config attribute
-
-        # self.config.general_config['lag'] = lag
-        # self.config.general_config['granularity'] = granularity
-        # self.config.general_config['min_cpu_limit'] = min_cpu_limit
-        # self.config.general_config['max_cpu_limit'] = max_cpu_limit
-        # self.config.general_config['window'] = window
         self.decision_file_path = decision_file_path or "data/decisions.txt"
-
-        # if save_metadata:
-        #     meta_out_file = self.data_dir / "metadata.txt"
-        #     meta = open(meta_out_file, "a")
-        #     meta.write("max_cpu_limit: " + str(self.config.general_config['max_cpu_limit']) + "\n")
-        #     meta.write("features: " + str(self.features) + "\n")
-        #     meta.write("window: " + str(self.config.general_config['window']) + "\n")
-        #     meta.write("lag: " + str(self.config.general_config['lag']) + "\n")
-        #     meta.write("granularity: " + str(self.config.general_config['granularity']) + "\n")
-        #     meta.write("min_cpu_limit: " + str(self.config.general_config['min_cpu_limit']) + "\n")
-        #     meta.close()
         self.save_metadata = save_metadata
 
     def get_current_cpu_limit(self):

--- a/src/vasim/recommender/cluster_state_provider/PredictiveFileClusterStateProvider.py
+++ b/src/vasim/recommender/cluster_state_provider/PredictiveFileClusterStateProvider.py
@@ -51,13 +51,6 @@ class PredictiveFileClusterStateProvider(FileClusterStateProvider):
 
         self.logger = logging.getLogger()
 
-        if self.save_metadata:
-            meta_out_file = self.data_dir / "metadata.txt"
-            meta = open(meta_out_file, "a")
-            # dump prediction_config to file
-            meta.write(f"prediction_config: {prediction_config}\n")
-            meta.close()
-
     def get_predicted_cores(self, data):
         def traditional_round(x):
             frac = x - math.floor(x)


### PR DESCRIPTION
# Pull Request

## Title

_Remove file generation of metadata.txt as being redundant_

---

## Description

_We switched metadata to always be metadata.json. However, we have some remants of metadata.txt lurking around when users set save_config=True. This PR removes generation of those redundant artifacts_

- **Issue link**: (optional) _https://github.com/microsoft/vasim/issues/73_

---

## Type of Change

_Indicate the type of change by choosing one (or more) of the following:_

 🔄 Refactor  


---

## Testing

_Ran unit tests_

---

## Additional Notes (optional)

_We don't use this file anywhere as we have metadata.json with more complex structure_

