### PR TITLE
Fixup pypi readme links

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -30,6 +30,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build
+    - name: Remove -dev version suffix
+      run: |
+        sed -i -r -e 's/^(VERSION = "[^"]+)-dev"/\1"/' setup.py
+        git diff || true
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ pytest
 
 #### Release Publishing Steps
 
-1. Create a PR to update the version in `pyproject.toml` to the new `M.m.p` version.
+1. Create a PR to update the `VERSION` in `setup.py` to the new `M.m.p` version.
 2. Once merged to `main`, create a tag with the new version:
 
     ```sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,12 +22,14 @@ classifiers = [
     "Topic :: System",
 ]
 license = { "file" = "LICENSE" }
-readme = { file = "README.md", content-type = "text/markdown" }
+dynamic = [
+    "readme",   # urls get dynamically mutated by the build process
+    "version",
+]
 maintainers = [
     { name = "VASim Maintainers", email = "vasim-maintainers@service.microsoft.com" },
 ]
 
-version = "0.1.2"
 requires-python = ">=3.9"
 dependencies = [
     # TODO: Remove version pinning or make it version dependent.

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,11 @@ import re
 
 from setuptools import setup
 
+# Adjust this version number to match the current release.
+# See maintainers notes in CONTRIBUTING.md for details.
+# Note: the "-dev" suffix is used to indicate a development version for local
+# testing and should remain (it will be stripped off for the release version).
 VERSION = "0.1.2-dev"
-version = f"v{VERSION.replace('-dev', '')}"
 
 
 # A simple routine to read and adjust the README.md for this module into a format
@@ -40,7 +43,8 @@ def _get_long_desc_from_readme(base_url: str) -> dict:
         }
 
 
+version_tag = f"v{VERSION.replace('-dev', '')}"  # alternatively: "main"
 setup(
     version=VERSION,
-    **_get_long_desc_from_readme(f"https://github.com/microsoft/vasim/tree/{version}/"),
+    **_get_long_desc_from_readme(f"https://github.com/microsoft/vasim/tree/{version_tag}/"),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+#
+# --------------------------------------------------------------------------
+#  Licensed under the MIT License. See LICENSE file in the project root for
+#  license information.
+#  Copyright (c) Microsoft Corporation.
+# --------------------------------------------------------------------------
+#
+"""Setup instructions for the vasim package."""
+
+import os
+import re
+
+from setuptools import setup
+
+VERSION = "0.1.2-dev"
+version = f"v{VERSION.replace('-dev', '')}"
+
+
+# A simple routine to read and adjust the README.md for this module into a format
+# suitable for packaging.
+# See Also: https://github.com/microsoft/MLOS/tree/main/mlos_core/setup.py
+def _get_long_desc_from_readme(base_url: str) -> dict:
+    pkg_dir = os.path.dirname(__file__)
+    readme_path = os.path.join(pkg_dir, "README.md")
+    if not os.path.isfile(readme_path):
+        return {
+            "long_description": "missing",
+        }
+    jsonc_re = re.compile(r"```jsonc")
+    link_re = re.compile(r"\]\(([^:#)]+)(#[a-zA-Z0-9_-]+)?\)")
+    with open(readme_path, mode="r", encoding="utf-8") as readme_fh:
+        lines = readme_fh.readlines()
+        # Tweak source source code links.
+        lines = [jsonc_re.sub(r"```json", line) for line in lines]
+        # Tweak the lexers for local expansion by pygments instead of github's.
+        lines = [link_re.sub(f"]({base_url}" + r"/\1\2)", line) for line in lines]
+        return {
+            "long_description": "".join(lines),
+            "long_description_content_type": "text/markdown",
+        }
+
+
+setup(
+    version=VERSION,
+    **_get_long_desc_from_readme(f"https://github.com/microsoft/vasim/tree/{version}/"),
+)


### PR DESCRIPTION
# Pull Request

## Title

Fixups for pypi package landing page links.

---

## Description

- Reintroduces `setup.py` to dynamically read and adjust the contents of `README.md` when constructing the whl package's `METADATA`.
- Moves `version` from `pyproject.toml` to `VERSION` in `setup.py` to do so.
- Includes a `-dev` suffix in `VERSION` and removes it on publishing.

- Closes #99 
---

## Type of Change

- 🛠️ Bug fix  
- 📝 Documentation update  

---

## Testing

- Locally unzipped and validated the whl file's METADATA file.
- Checked the `sed` rule adjusts the `VERSION` to strip `-dev` as expected during release.

---