### PR TITLE
Fixes#111 : Fix print statements in scaler output

### DIFF
--- a/src/vasim/simulator/SimulatedInfraScaler.py
+++ b/src/vasim/simulator/SimulatedInfraScaler.py
@@ -77,18 +77,18 @@ class SimulatedInfraScaler:
                     self.cluster_state_provider.set_cpu_limit(new_limit)
                 self.last_scaling_time = time_now
                 self.logger.info(">>>updated to %f cores", new_limit)
-                self.logger.info("Having a post-scaling %f minute nap.", self.recovery_time)
+                self.logger.info("Having a post-scaling %d minute nap.", self.recovery_time)
                 return True
             elif self.last_scaling_time is not None:
                 self.logger.info(
-                    "Waiting to scale %f minutes, current minutes %f, new_limit: %f",
+                    "Waiting to scale %d minutes, current minutes %d, new_limit: %f",
                     self.recovery_time * 60 - (time_now - self.last_scaling_time).seconds // 60,
                     minutes,
                     new_limit,
                 )
         else:
             self.logger.info(
-                "Waiting to scale %f minutes, current minutes %f, decision of cores to add or subtract: %f",
+                "Waiting to scale %d minutes, current minutes %d, decision of cores to add or subtract: %f",
                 0,
                 minutes,
                 new_limit,

--- a/src/vasim/simulator/SimulatedInfraScaler.py
+++ b/src/vasim/simulator/SimulatedInfraScaler.py
@@ -61,7 +61,7 @@ class SimulatedInfraScaler:
             # We only want to scale if the recovery time has passed since the last scaling event
             # or if there was no previous scaling event
             if self.last_scaling_time is None or (time_now - self.last_scaling_time).seconds > self.recovery_time * 60:
-                self.logger.info(">>>attempting to scale to %d cores from %d", new_limit, current_cpu_limit)
+                self.logger.info(">>>attempting to scale to %f cores from %f", new_limit, current_cpu_limit)
                 if new_limit < self.cluster_state_provider.config.general_config["min_cpu_limit"]:
                     self.logger.info(">>>not scaling, would go below min cores")
                     self.cluster_state_provider.set_cpu_limit(
@@ -76,19 +76,19 @@ class SimulatedInfraScaler:
                 else:
                     self.cluster_state_provider.set_cpu_limit(new_limit)
                 self.last_scaling_time = time_now
-                self.logger.info(">>>updated to %d cores", new_limit)
-                self.logger.info("Having a post-scaling %d minute nap.", self.recovery_time)
+                self.logger.info(">>>updated to %f cores", new_limit)
+                self.logger.info("Having a post-scaling %f minute nap.", self.recovery_time)
                 return True
             elif self.last_scaling_time is not None:
                 self.logger.info(
-                    "Waiting to scale %d minutes, current minutes %d, new_limit: %d",
+                    "Waiting to scale %f minutes, current minutes %f, new_limit: %f",
                     self.recovery_time * 60 - (time_now - self.last_scaling_time).seconds // 60,
                     minutes,
                     new_limit,
                 )
         else:
             self.logger.info(
-                "Waiting to scale %d minutes, current minutes %d, decision of cores to add or subtract: %d",
+                "Waiting to scale %f minutes, current minutes %f, decision of cores to add or subtract: %f",
                 0,
                 minutes,
                 new_limit,


### PR DESCRIPTION
# Pull Request

### Fixes#111: Fix print statements in scaler output

## Description
Have Switched all ```%d``` to ```%f``` in [SimulatedInfraScaler.py](https://github.com/microsoft/vasim/blob/45197515a145dae625d2230b9e7d62d9973d615c/src/vasim/simulator/SimulatedInfraScaler.py)
Fixes: #111 


