### PR TITLE
fix(utils): validate data_dir and reject symlinks escaping it

### DIFF
--- a/src/vasim/commons/utils.py
+++ b/src/vasim/commons/utils.py
@@ -37,18 +37,32 @@ def list_perf_event_log_files(data_dir: Path):
     This function searches through the specified directory and its subdirectories for CSV files. It then filters
     the list to include only those files that have "perf_event_log" at the end of their file names.
 
+    Files reached through a symlink that points outside ``data_dir`` are skipped, as is
+    a ``data_dir`` that does not exist or is not a directory.
+
     Args:
         data_dir (Path): The directory path where the CSV files are located.
 
     Returns:
         List[Path]: A list of file paths that match the "perf_event_log" pattern. If no files are found,
                     an empty list is returned. Additionally, an error message is printed if no matching
-                    files are found in the directory.
+                    files are found in the directory, or if `data_dir` is not a usable directory.
     """
-    csv_files = list(data_dir.glob("**/*.csv"))
+    data_dir = Path(data_dir)
+    if not data_dir.is_dir():
+        print(f"Error: data_dir is not an existing directory: {data_dir}")
+        return []
 
-    # Filter CSV files that end with "perf_event_log"
-    perf_event_log_files = [file for file in csv_files if file.stem.endswith("perf_event_log")]
+    root = data_dir.resolve()
+    perf_event_log_files = []
+    for file in data_dir.glob("**/*.csv"):
+        if not file.stem.endswith("perf_event_log"):
+            continue
+        # glob follows symlinks, so a link under data_dir can resolve anywhere
+        # on the filesystem; keep only what really lives under the directory.
+        if not file.is_file() or not file.resolve().is_relative_to(root):
+            continue
+        perf_event_log_files.append(file)
 
     if not perf_event_log_files:
         print(f"Error: no csvs ending in perf_event_log found in data_dir: {data_dir}")

--- a/tests/test_commons/test_utils.py
+++ b/tests/test_commons/test_utils.py
@@ -24,6 +24,7 @@ Test cases:
 Classes:
     - TestListPerfEventLogFiles: Contains the test cases for `list_perf_event_log_files`.
 """
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -33,8 +34,9 @@ from vasim.commons.utils import list_perf_event_log_files
 
 class TestListPerfEventLogFiles(unittest.TestCase):
 
+    @patch("vasim.commons.utils.Path.is_dir", return_value=True)
     @patch("vasim.commons.utils.Path.glob")
-    def test_list_perf_event_log_files_returns_csv_files(self, mock_glob):
+    def test_list_perf_event_log_files_returns_csv_files(self, mock_glob, _mock_is_dir):
         # Mock the return value of Path.glob to simulate CSV files ending with "perf_event_log"
         mock_files = [
             MagicMock(spec=Path, stem="file1_perf_event_log", suffix=".csv"),
@@ -48,16 +50,18 @@ class TestListPerfEventLogFiles(unittest.TestCase):
         for file in result:
             self.assertTrue(file.stem.endswith("perf_event_log"))
 
+    @patch("vasim.commons.utils.Path.is_dir", return_value=True)
     @patch("vasim.commons.utils.Path.glob")
-    def test_list_perf_event_log_files_returns_empty_list_on_empty_dir(self, mock_glob):
+    def test_list_perf_event_log_files_returns_empty_list_on_empty_dir(self, mock_glob, _mock_is_dir):
         # Mock the return value of Path.glob to simulate no CSV files
         mock_glob.return_value = []
 
         result = list_perf_event_log_files(Path("tests/tests_commons"))
         self.assertEqual(len(result), 0)
 
+    @patch("vasim.commons.utils.Path.is_dir", return_value=True)
     @patch("vasim.commons.utils.Path.glob")
-    def test_list_perf_event_log_files_returns_empty_list_on_non_perf_event_logs(self, mock_glob):
+    def test_list_perf_event_log_files_returns_empty_list_on_non_perf_event_logs(self, mock_glob, _mock_is_dir):
         # Mock the return value of Path.glob to simulate non CSV file and non perf_event_log CSV file
         mock_glob.return_value = [
             MagicMock(spec=Path, stem="file1", suffix=".json"),
@@ -66,6 +70,60 @@ class TestListPerfEventLogFiles(unittest.TestCase):
 
         result = list_perf_event_log_files(Path("data/"))
         self.assertEqual(len(result), 0)
+
+
+class TestListPerfEventLogFilesOnDisk(unittest.TestCase):
+    """Filesystem-backed coverage for the input checks added for #18."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self._tmp.name) / "data"
+        self.data_dir.mkdir()
+        self.addCleanup(self._tmp.cleanup)
+
+    def test_returns_matching_csv_from_a_real_directory(self):
+        wanted = self.data_dir / "node_perf_event_log.csv"
+        wanted.write_text("ts,cpu\n")
+        (self.data_dir / "unrelated.csv").write_text("ts,cpu\n")
+
+        result = list_perf_event_log_files(self.data_dir)
+
+        self.assertEqual([p.name for p in result], ["node_perf_event_log.csv"])
+
+    def test_missing_data_dir_returns_empty_list(self):
+        self.assertEqual(list_perf_event_log_files(self.data_dir / "absent"), [])
+
+    def test_file_passed_as_data_dir_returns_empty_list(self):
+        not_a_dir = self.data_dir / "a_perf_event_log.csv"
+        not_a_dir.write_text("ts,cpu\n")
+
+        self.assertEqual(list_perf_event_log_files(not_a_dir), [])
+
+    def test_symlink_escaping_data_dir_is_skipped(self):
+        outside = Path(self._tmp.name) / "outside_perf_event_log.csv"
+        outside.write_text("ts,cpu\n")
+        link = self.data_dir / "linked_perf_event_log.csv"
+        try:
+            link.symlink_to(outside)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks unavailable on this platform")
+
+        self.assertEqual(list_perf_event_log_files(self.data_dir), [])
+
+    def test_symlink_staying_inside_data_dir_is_kept(self):
+        target = self.data_dir / "real_perf_event_log.csv"
+        target.write_text("ts,cpu\n")
+        link = self.data_dir / "nested"
+        link.mkdir()
+        inner = link / "alias_perf_event_log.csv"
+        try:
+            inner.symlink_to(target)
+        except (OSError, NotImplementedError):
+            self.skipTest("symlinks unavailable on this platform")
+
+        result = sorted(p.name for p in list_perf_event_log_files(self.data_dir))
+
+        self.assertEqual(result, ["alias_perf_event_log.csv", "real_perf_event_log.csv"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #18

Picking up the sanitization ask on `list_perf_event_log_files`. Two things the bare `data_dir.glob("**/*.csv")` was letting through:

A `data_dir` that doesn't exist, or that's a file rather than a directory, globs to nothing and you get "no csvs ending in perf_event_log found in data_dir" — the same message a genuinely empty directory gives. That sends you looking for missing CSVs when the real problem is the path. Those now say so explicitly.

The bigger one is that `glob` follows symlinks, so a link sitting under `data_dir` can resolve to a CSV anywhere on the filesystem and get read as trace data. Each match is now resolved and kept only if it still lands under `data_dir`. A symlink that stays inside the directory keeps working — I didn't want to break anyone laying out traces that way — and there's a test for both directions.

Return values are unchanged for the normal case: I glob the unresolved `data_dir` and only resolve for the containment check, so callers get the same paths they got before.

The three existing tests mock `Path.glob` and pass `tests/tests_commons`, which isn't a real directory, so the new `is_dir()` check would have short-circuited them — they now patch `is_dir` alongside `glob`. I also added five filesystem-backed tests that use a real temp directory instead of mocks.

```
$ PYTHONPATH=src pytest tests/test_commons/test_utils.py
8 passed
```

black, isort and pydocstringformatter are clean on both files. The full suite errors on 10 tests locally from a missing pandas, but identically on a clean `main` — unrelated to this change.